### PR TITLE
Node 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,11 @@ matrix:
         - node_js: 4.0
         - node_js: 4.1
         - node_js: 4.2
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
+sudo: false
 language: node_js
 node_js:
+  - 0.12
   - 0.10
+  - 4.0
+  - 4.1
+  - 4.2
+matrix:
+    allow_failures:
+        - node_js: 4.0
+        - node_js: 4.1
+        - node_js: 4.2

--- a/package.json
+++ b/package.json
@@ -2,14 +2,22 @@
   "name": "pelias-admin-lookup",
   "version": "2.0.8",
   "description": "A fast, local, streaming Quattroshapes administrative hierarchy lookup.",
-  "keywords": ["local", "stream", "quattroshapes", "coarse", "reverse-geocoder"],
+  "keywords": [
+    "local",
+    "stream",
+    "quattroshapes",
+    "coarse",
+    "reverse-geocoder"
+  ],
   "author": "mapzen",
   "main": "lib/master.js",
   "scripts": {
     "test": "node test/test.js | tap-spec",
     "test-web-app": "node test/app/server.js",
     "test-lookups": "node test/lookup_results.js | tap-spec",
-    "test-stream": "node test/lookup_stream.js | tap-spec"
+    "test-stream": "node test/lookup_stream.js | tap-spec",
+    "lint": "jshint .",
+    "validate": "npm ls"
   },
   "dependencies": {
     "pelias-config": "^0.x.x",
@@ -23,11 +31,11 @@
     "require-dir": "0.2.0"
   },
   "devDependencies": {
-    "precommit-hook": "1.0.7",
+    "express": "^4.x.x",
     "pelias-model": "0.1.1",
-    "tape": "3.0.3",
+    "precommit-hook": "^1.0.7",
     "tap-spec": "2.1.2",
-    "express": "^4.x.x"
+    "tape": "3.0.3"
   },
   "repository": {
     "type": "git",
@@ -37,5 +45,10 @@
   "bugs": {
     "url": "https://github.com/pelias/admin-lookup/issues"
   },
-  "homepage": "https://github.com/pelias/admin-lookup"
+  "homepage": "https://github.com/pelias/admin-lookup",
+  "pre-commit": [
+    "lint",
+    "validate",
+    "test"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "0.9.0",
     "polygon-lookup": "^1.0.0",
     "pelias-logger": "^0.x.x",
-    "microtime": "^1.x.x",
+    "microtime": "^2.x.x",
     "require-dir": "0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
By upgrading from microtime 1.x to 2.x, all tests pass on Node 4. I've also tested the Geonames and Openaddresses importer locally and they looked good.